### PR TITLE
Add patch_spatial parameter to improve conditional image resizing

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -39,12 +39,17 @@ def _get_inner_dit(model) -> torch.nn.Module:
 
 
 def _prepare_cond_image(image: torch.Tensor, latent_h: int, latent_w: int,
-                        device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+                        device: torch.device, dtype: torch.dtype,
+                        patch_spatial: int = 2) -> torch.Tensor:
     """ComfyUI IMAGE (B,H,W,3) in [0,1] → (1,3,H*8,W*8) in [-1,1].
 
     The LLLite ``conditioning1`` Conv has stride 16, so the cond image must be
     sized to ``latent_HW * 8`` in input pixel space (= ``token_HW * 16`` after
-    DiT patchify with patch_spatial=2).
+    DiT patchify with patch_spatial=2). The DiT internally pads the latent up
+    to a multiple of ``patch_spatial`` (see ``MiniTrainDIT.forward`` →
+    ``pad_to_patch_size``), so we mirror that rounding here — otherwise odd
+    latent dims (e.g. 1032 px → 129 latent) yield a token-count mismatch that
+    silently bypasses every LLLite module.
     """
     if image.ndim == 4 and image.shape[-1] == 3:
         # (B, H, W, 3) -> (B, 3, H, W)
@@ -53,8 +58,10 @@ def _prepare_cond_image(image: torch.Tensor, latent_h: int, latent_w: int,
         raise ValueError(f"Unexpected cond image shape: {tuple(image.shape)} (expected B,H,W,3)")
 
     img = img[:1]  # use first frame only
-    target_h = latent_h * 8
-    target_w = latent_w * 8
+    padded_h = ((latent_h + patch_spatial - 1) // patch_spatial) * patch_spatial
+    padded_w = ((latent_w + patch_spatial - 1) // patch_spatial) * patch_spatial
+    target_h = padded_h * 8
+    target_w = padded_w * 8
     if img.shape[-2] != target_h or img.shape[-1] != target_w:
         img = F.interpolate(img, size=(target_h, target_w), mode="bicubic", align_corners=False)
         img = img.clamp(0.0, 1.0)
@@ -103,6 +110,7 @@ class AnimaLLLiteApply:
             aspp_dilations = ASPP_DEFAULT_DILATIONS
 
         dit = _get_inner_dit(model)
+        patch_spatial = int(getattr(dit, "patch_spatial", 2))
         lllite = ControlNetLLLiteDiT(
             dit,
             cond_emb_dim=ce_dim,
@@ -155,7 +163,7 @@ class AnimaLLLiteApply:
             key = (latent_h, latent_w, device, dtype)
             if cache["key"] != key or cache["cond_image_pp"] is None:
                 cache["cond_image_pp"] = _prepare_cond_image(
-                    src_image, latent_h, latent_w, device, dtype
+                    src_image, latent_h, latent_w, device, dtype, patch_spatial
                 )
                 cache["key"] = key
 


### PR DESCRIPTION
This pull request updates the way conditional images are prepared for DiT-based models in `nodes.py`, ensuring that image padding and resizing are consistent with the model's internal patching logic. The main goal is to prevent mismatches between the expected and actual token counts, which could cause LLLite modules to be bypassed. The most important changes are:

**Conditioning Image Preparation Consistency:**

* The `_prepare_cond_image` function now pads the target latent dimensions (`latent_h`, `latent_w`) up to the nearest multiple of `patch_spatial` before resizing, mirroring the DiT model's internal padding logic and preventing token-count mismatches.
* The `patch_spatial` parameter is explicitly passed through the code path: it's read from the DiT model (defaulting to 2 if not present) and threaded into `_prepare_cond_image`, making the padding logic adaptive to model configuration. [[1]](diffhunk://#diff-e485eb8bfa77e53e217e9b400c67298309ef679c6ecd69a1174366f48bb93499L42-R52) [[2]](diffhunk://#diff-e485eb8bfa77e53e217e9b400c67298309ef679c6ecd69a1174366f48bb93499R113) [[3]](diffhunk://#diff-e485eb8bfa77e53e217e9b400c67298309ef679c6ecd69a1174366f48bb93499L158-R166)

**Bug Fix / Robustness:**

* This change fixes a subtle bug where odd latent sizes could silently bypass LLLite modules due to token-count mismatches, making the code more robust and predictable.

---

Closes #2.