### PR TITLE
feat: Support inpainting (4ch input) weights and add mask processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,39 @@ Place LLLite weights (`.safetensors`) under `ComfyUI/models/controlnet/`.
 | `lllite_name` | filename | from `models/controlnet/` |
 | `image` | IMAGE | control image (any resolution; auto-resized to latent×8) |
 | `strength` | FLOAT | LLLite multiplier (default 1.0) |
+| `start_percent` | FLOAT | start of the active sampling window (0.0 = sigma_max) |
+| `end_percent` | FLOAT | end of the active sampling window (1.0 = sigma_min) |
+| `mask` *(optional)* | MASK | required when the weights are 4-channel (inpaint); white = inpaint area, black = keep |
 
 Output: patched `MODEL`.
 
 All architectural parameters (`cond_emb_dim`, `mlp_dim`, `cond_dim`,
-`cond_resblocks`, `use_aspp`, `aspp_dilations`, `target_layers`) are baked
-into the trained weights and read automatically from the safetensors
-metadata — they are not exposed as node inputs because changing them would
-just cause load errors.
+`cond_resblocks`, `use_aspp`, `aspp_dilations`, `target_layers`,
+`cond_in_channels`, `inpaint_masked_input`) are baked into the trained
+weights and read automatically from the safetensors metadata — they are
+not exposed as node inputs because changing them would just cause load
+errors.
+
+### Inpainting (4-channel) weights
+
+If the loaded weights were trained with `--lllite_cond_in_channels=4`
+(inpaint mode), the node also requires a `MASK` input. The mask convention
+matches the sd-scripts training/inference code:
+
+* `white` (1.0) = inpaint area (the region the model should fill)
+* `black` (0.0) = keep
+
+The mask is resized to match the control image (nearest-neighbor),
+binarized at 0.5, and concatenated with the RGB control image as a 4th
+channel (rescaled to `[-1, +1]` to match the RGB range). When the weights
+were trained with `--lllite_inpaint_masked_input`, the RGB channels are
+also zeroed inside the mask region before concatenation — this is read
+from the weights metadata and applied automatically.
+
+3-channel weights continue to work with no mask input; if a mask is
+connected to a 3-channel LLLite the node logs a warning and ignores it.
+A 4-channel weight without a mask raises a `ValueError` rather than
+silently substituting an empty mask.
 
 ## How it works
 
@@ -59,7 +84,9 @@ just cause load errors.
   embedded by the v2 `conditioning1` trunk (Conv 4×4 s=4 → Conv 3×3 s=1 →
   Conv 4×4 s=4 with GroupNorm/SiLU, optional ResBlocks, optional ASPP, 1×1
   projection, LayerNorm) to a per-token feature map matching the DiT token
-  grid.
+  grid. For 4-channel (inpaint) weights, the mask is resized with
+  nearest-neighbor, binarized, rescaled to `[-1, +1]`, and concatenated as
+  the 4th channel of the cond image before this trunk.
 * Each LLLite module applies the v2 forward: `down → silu → concat with
   (cond + per-module depth-embedding) → mid → FiLM(γ, β) → silu → up`,
   added to the original Linear input.
@@ -89,6 +116,9 @@ The expected safetensors metadata keys are:
 * `lllite.use_aspp`, `lllite.aspp_dilations`
 * `lllite.target_atomics` (canonical, comma-separated atomic specifiers) —
   falls back to `lllite.target_layers` for older v2 snapshots
+* `lllite.cond_in_channels` (`"3"` standard / `"4"` inpaint; defaults to `3`)
+* `lllite.inpaint_masked_input` (`"true"` / `"false"`; defaults to `false`,
+  only meaningful when `cond_in_channels=4`)
 
 **Legacy weights with `lllite_modules.{i}.*` keys (the pre-v2 format) are
 rejected on load.** Re-train against the current sd-scripts codebase.

--- a/control_net_lllite_anima.py
+++ b/control_net_lllite_anima.py
@@ -156,12 +156,15 @@ class _Conditioning1(nn.Module):
         n_resblocks: int,
         use_aspp: bool = False,
         aspp_dilations: Tuple[int, ...] = ASPP_DEFAULT_DILATIONS,
+        cond_in_channels: int = 3,
     ):
         super().__init__()
         assert cond_dim % 2 == 0, f"cond_dim must be even, got {cond_dim}"
+        assert cond_in_channels >= 1, f"cond_in_channels must be >= 1, got {cond_in_channels}"
         ch_half = cond_dim // 2
 
-        self.conv1 = nn.Conv2d(3, ch_half, kernel_size=4, stride=4, padding=0)
+        self.cond_in_channels = cond_in_channels
+        self.conv1 = nn.Conv2d(cond_in_channels, ch_half, kernel_size=4, stride=4, padding=0)
         self.norm1 = _gn(ch_half)
         self.conv2 = nn.Conv2d(ch_half, ch_half, kernel_size=3, stride=1, padding=1)
         self.norm2 = _gn(ch_half)
@@ -327,6 +330,8 @@ class ControlNetLLLiteDiT(nn.Module):
         cond_resblocks: int = 1,
         use_aspp: bool = False,
         aspp_dilations: Tuple[int, ...] = ASPP_DEFAULT_DILATIONS,
+        cond_in_channels: int = 3,
+        inpaint_masked_input: bool = False,
     ):
         super().__init__()
 
@@ -342,10 +347,15 @@ class ControlNetLLLiteDiT(nn.Module):
         self.cond_resblocks = cond_resblocks
         self.use_aspp = use_aspp
         self.aspp_dilations = tuple(aspp_dilations) if use_aspp else ()
+        # 4ch (RGB+mask) inpainting metadata. `inpaint_masked_input` records the training-time
+        # RGB-masking policy for cond_image preparation; it does not alter the forward pass here.
+        self.cond_in_channels = cond_in_channels
+        self.inpaint_masked_input = inpaint_masked_input
 
         self.conditioning1 = _Conditioning1(
             cond_dim, cond_emb_dim, cond_resblocks,
             use_aspp=use_aspp, aspp_dilations=aspp_dilations,
+            cond_in_channels=cond_in_channels,
         )
 
         modules = self._create_modules(dit, cond_emb_dim, mlp_dim, atomics, dropout, multiplier)
@@ -358,11 +368,16 @@ class ControlNetLLLiteDiT(nn.Module):
             m._depth_embeds_ref = [self.depth_embeds]
 
         aspp_info = f"aspp={'on' + str(list(self.aspp_dilations)) if use_aspp else 'off'}"
+        inpaint_info = (
+            f", inpaint=on(masked_input={inpaint_masked_input})" if cond_in_channels != 3 else ""
+        )
         logger.info(
             "ControlNet-LLLite (Anima v%s): created %d modules for target=%r "
-            "(atomics=%s), cond_dim=%d, cond_resblocks=%d, %s, cond_emb_dim=%d, mlp_dim=%d",
+            "(atomics=%s), cond_in_channels=%d, cond_dim=%d, cond_resblocks=%d, %s, "
+            "cond_emb_dim=%d, mlp_dim=%d%s",
             LLLITE_ARCH_VERSION, n, target_layers, list(atomics),
-            cond_dim, cond_resblocks, aspp_info, cond_emb_dim, mlp_dim,
+            cond_in_channels, cond_dim, cond_resblocks, aspp_info, cond_emb_dim, mlp_dim,
+            inpaint_info,
         )
 
     @staticmethod

--- a/nodes.py
+++ b/nodes.py
@@ -38,10 +38,8 @@ def _get_inner_dit(model) -> torch.nn.Module:
     return dit
 
 
-def _prepare_cond_image(image: torch.Tensor, latent_h: int, latent_w: int,
-                        device: torch.device, dtype: torch.dtype,
-                        patch_spatial: int = 2) -> torch.Tensor:
-    """ComfyUI IMAGE (B,H,W,3) in [0,1] → (1,3,H*8,W*8) in [-1,1].
+def _target_cond_hw(latent_h: int, latent_w: int, patch_spatial: int = 2) -> tuple[int, int]:
+    """Return the (H, W) the cond image / mask must be resized to.
 
     The LLLite ``conditioning1`` Conv has stride 16, so the cond image must be
     sized to ``latent_HW * 8`` in input pixel space (= ``token_HW * 16`` after
@@ -51,6 +49,15 @@ def _prepare_cond_image(image: torch.Tensor, latent_h: int, latent_w: int,
     latent dims (e.g. 1032 px → 129 latent) yield a token-count mismatch that
     silently bypasses every LLLite module.
     """
+    padded_h = ((latent_h + patch_spatial - 1) // patch_spatial) * patch_spatial
+    padded_w = ((latent_w + patch_spatial - 1) // patch_spatial) * patch_spatial
+    return padded_h * 8, padded_w * 8
+
+
+def _prepare_cond_image(image: torch.Tensor, latent_h: int, latent_w: int,
+                        device: torch.device, dtype: torch.dtype,
+                        patch_spatial: int = 2) -> torch.Tensor:
+    """ComfyUI IMAGE (B,H,W,3) in [0,1] → (1,3,H*8,W*8) in [-1,1]."""
     if image.ndim == 4 and image.shape[-1] == 3:
         # (B, H, W, 3) -> (B, 3, H, W)
         img = image.permute(0, 3, 1, 2).contiguous()
@@ -58,15 +65,50 @@ def _prepare_cond_image(image: torch.Tensor, latent_h: int, latent_w: int,
         raise ValueError(f"Unexpected cond image shape: {tuple(image.shape)} (expected B,H,W,3)")
 
     img = img[:1]  # use first frame only
-    padded_h = ((latent_h + patch_spatial - 1) // patch_spatial) * patch_spatial
-    padded_w = ((latent_w + patch_spatial - 1) // patch_spatial) * patch_spatial
-    target_h = padded_h * 8
-    target_w = padded_w * 8
+    target_h, target_w = _target_cond_hw(latent_h, latent_w, patch_spatial)
     if img.shape[-2] != target_h or img.shape[-1] != target_w:
         img = F.interpolate(img, size=(target_h, target_w), mode="bicubic", align_corners=False)
         img = img.clamp(0.0, 1.0)
     img = img * 2.0 - 1.0
     return img.to(device=device, dtype=dtype)
+
+
+def _prepare_mask(mask: torch.Tensor, latent_h: int, latent_w: int,
+                  device: torch.device, dtype: torch.dtype,
+                  patch_spatial: int = 2) -> torch.Tensor:
+    """ComfyUI MASK (B,H,W) in [0,1] → (1,1,H*8,W*8) binarized at 0.5.
+
+    Returns the mask in ``{0.0, 1.0}`` (1 = inpaint area, 0 = keep). The caller
+    is responsible for the ``*2-1`` rescale before concat with RGB.
+    """
+    if mask.ndim == 3:
+        m = mask.unsqueeze(1)              # (B, 1, H, W)
+    elif mask.ndim == 4 and mask.shape[1] == 1:
+        m = mask
+    else:
+        raise ValueError(f"Unexpected mask shape: {tuple(mask.shape)} (expected B,H,W or B,1,H,W)")
+
+    m = m[:1]
+    target_h, target_w = _target_cond_hw(latent_h, latent_w, patch_spatial)
+    if m.shape[-2] != target_h or m.shape[-1] != target_w:
+        m = F.interpolate(m.float(), size=(target_h, target_w), mode="nearest")
+    m = (m >= 0.5).to(dtype=dtype)
+    return m.to(device=device)
+
+
+def _build_inpaint_cond_image(rgb_pm1: torch.Tensor, mask01: torch.Tensor,
+                              masked_input: bool) -> torch.Tensor:
+    """rgb_pm1: (1,3,H,W) in [-1,1], mask01: (1,1,H,W) in {0,1}. Returns (1,4,H,W).
+
+    Mirrors ``_build_inpaint_cond_image`` in the sd-scripts training / inference
+    code: the mask channel is rescaled to ``[-1, +1]`` (matches the RGB range),
+    and if ``masked_input`` is set the RGB is zeroed where ``mask >= 0.5``.
+    """
+    if masked_input:
+        keep = (mask01 < 0.5).to(rgb_pm1.dtype)
+        rgb_pm1 = rgb_pm1 * keep
+    mask_pm1 = mask01.to(rgb_pm1.dtype) * 2.0 - 1.0
+    return torch.cat([rgb_pm1, mask_pm1], dim=1)
 
 
 class AnimaLLLiteApply:
@@ -81,13 +123,18 @@ class AnimaLLLiteApply:
                 "start_percent": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.001}),
                 "end_percent": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.001}),
             },
+            "optional": {
+                # Required when the loaded weights are 4ch (inpaint). White = inpaint area,
+                # black = keep. Mismatch with the weights' cond_in_channels is reported below.
+                "mask": ("MASK",),
+            },
         }
 
     RETURN_TYPES = ("MODEL",)
     FUNCTION = "apply"
     CATEGORY = "loaders"
 
-    def apply(self, model, lllite_name, image, strength, start_percent, end_percent):
+    def apply(self, model, lllite_name, image, strength, start_percent, end_percent, mask=None):
         weights_path = folder_paths.get_full_path("controlnet", lllite_name)
         if weights_path is None or not os.path.isfile(weights_path):
             raise FileNotFoundError(f"LLLite weights not found: {lllite_name}")
@@ -108,6 +155,22 @@ class AnimaLLLiteApply:
             aspp_dilations = tuple(int(d) for d in aspp_dilations_meta.split(",") if d.strip())
         else:
             aspp_dilations = ASPP_DEFAULT_DILATIONS
+        cond_in_channels = int(meta.get("lllite.cond_in_channels", 3))
+        inpaint_masked_input = str(meta.get("lllite.inpaint_masked_input", "false")).lower() == "true"
+
+        # Mask / cond_in_channels consistency: 4ch weights need a MASK, 3ch weights ignore it.
+        if cond_in_channels == 4 and mask is None:
+            raise ValueError(
+                f"LLLite weights '{lllite_name}' were trained with cond_in_channels=4 "
+                f"(inpaint mode) and require a MASK input. Connect a MASK to the node "
+                f"(white = inpaint area, black = keep)."
+            )
+        if cond_in_channels != 4 and mask is not None:
+            logger.warning(
+                "LLLite weights '%s' are %dch; the provided MASK input will be ignored.",
+                lllite_name, cond_in_channels,
+            )
+            mask = None
 
         dit = _get_inner_dit(model)
         patch_spatial = int(getattr(dit, "patch_spatial", 2))
@@ -121,6 +184,8 @@ class AnimaLLLiteApply:
             cond_resblocks=cond_resblocks,
             use_aspp=use_aspp,
             aspp_dilations=aspp_dilations,
+            cond_in_channels=cond_in_channels,
+            inpaint_masked_input=inpaint_masked_input,
         )
         load_lllite_weights(lllite, weights_path, strict=False)
         lllite.eval().requires_grad_(False)
@@ -130,8 +195,10 @@ class AnimaLLLiteApply:
         sigma_start = float(model_sampling.percent_to_sigma(start_percent))
         sigma_end = float(model_sampling.percent_to_sigma(end_percent))
 
-        # Capture image tensor (cloned to detach from any upstream caching)
+        # Capture image / mask tensors (cloned to detach from any upstream caching)
         src_image = image.detach().clone()
+        src_mask = mask.detach().clone() if mask is not None else None
+        is_inpaint = cond_in_channels == 4
 
         # Cache for the per-resolution preprocessed cond image (avoids repeat resize)
         cache = {"cond_image_pp": None, "key": None, "lllite_loaded_to": None}
@@ -162,9 +229,18 @@ class AnimaLLLiteApply:
 
             key = (latent_h, latent_w, device, dtype)
             if cache["key"] != key or cache["cond_image_pp"] is None:
-                cache["cond_image_pp"] = _prepare_cond_image(
+                rgb = _prepare_cond_image(
                     src_image, latent_h, latent_w, device, dtype, patch_spatial
                 )
+                if is_inpaint:
+                    mk = _prepare_mask(
+                        src_mask, latent_h, latent_w, device, dtype, patch_spatial
+                    )
+                    cache["cond_image_pp"] = _build_inpaint_cond_image(
+                        rgb, mk, inpaint_masked_input
+                    )
+                else:
+                    cache["cond_image_pp"] = rgb
                 cache["key"] = key
 
             lllite.set_multiplier(strength)


### PR DESCRIPTION
This pull request adds robust support for inpainting (4-channel) weights to the LLLite ControlNet integration, allowing the node to handle both standard and inpaint-trained weights. It introduces a required mask input for inpaint weights, enforces correct mask usage, and ensures preprocessing matches the training convention. The documentation and model metadata handling are updated accordingly.

**Inpainting (4-channel) weights support:**

* Added support for inpaint-trained LLLite weights (`cond_in_channels=4`), requiring a `MASK` input that specifies the inpaint area (white = inpaint, black = keep). The mask is preprocessed and concatenated with the control image as a 4th channel, following the training/inference convention. If the mask is missing for 4-channel weights, a `ValueError` is raised; if provided for 3-channel weights, it is ignored with a warning. (`README.md`, `nodes.py`, `control_net_lllite_anima.py`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R36-R68) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L62-R89) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R119-R121) [[4]](diffhunk://#diff-e485eb8bfa77e53e217e9b400c67298309ef679c6ecd69a1174366f48bb93499R126-R137) [[5]](diffhunk://#diff-e485eb8bfa77e53e217e9b400c67298309ef679c6ecd69a1174366f48bb93499R158-R173)
* Implemented mask preprocessing utilities: resizing, binarization, and concatenation with the RGB image, including optional zeroing of RGB in the masked region if `inpaint_masked_input` is set in the weights metadata. (`nodes.py`) [[1]](diffhunk://#diff-e485eb8bfa77e53e217e9b400c67298309ef679c6ecd69a1174366f48bb93499R52-R113) [[2]](diffhunk://#diff-e485eb8bfa77e53e217e9b400c67298309ef679c6ecd69a1174366f48bb93499L165-R243)

**Model and node interface updates:**

* Extended model and node initialization to accept and propagate `cond_in_channels` and `inpaint_masked_input` metadata, ensuring correct architecture and logging. (`control_net_lllite_anima.py`, `nodes.py`) [[1]](diffhunk://#diff-fbe95727e7fe0d85a8d75dba3ce2aabf421ddce836b555fe2f649fb1fc7847afR159-R167) [[2]](diffhunk://#diff-fbe95727e7fe0d85a8d75dba3ce2aabf421ddce836b555fe2f649fb1fc7847afR333-R334) [[3]](diffhunk://#diff-fbe95727e7fe0d85a8d75dba3ce2aabf421ddce836b555fe2f649fb1fc7847afR350-R358) [[4]](diffhunk://#diff-fbe95727e7fe0d85a8d75dba3ce2aabf421ddce836b555fe2f649fb1fc7847afR371-R380) [[5]](diffhunk://#diff-e485eb8bfa77e53e217e9b400c67298309ef679c6ecd69a1174366f48bb93499R187-R188)
* Updated node input schema to include an optional `mask` input, with runtime checks for consistency with loaded weights. (`nodes.py`) [[1]](diffhunk://#diff-e485eb8bfa77e53e217e9b400c67298309ef679c6ecd69a1174366f48bb93499R126-R137) [[2]](diffhunk://#diff-e485eb8bfa77e53e217e9b400c67298309ef679c6ecd69a1174366f48bb93499R158-R173)

**Documentation improvements:**

* Expanded the README with detailed instructions for using inpaint weights, mask conventions, and new metadata keys (`lllite.cond_in_channels`, `lllite.inpaint_masked_input`). (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R36-R68) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L62-R89) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R119-R121)